### PR TITLE
ADD: EC2 Instance Name

### DIFF
--- a/ec2-exercises/samconfig.toml
+++ b/ec2-exercises/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default.deploy.parameters]
+stack_name = "project-03-ec2-sam-stack"
+resolve_s3 = true
+s3_prefix = "project-03-ec2-sam-stack"
+region = "us-east-1"
+profile = "September-Admin"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "EC2InstanceType=\"t2.micro\""
+image_repositories = []

--- a/ec2-exercises/template.yaml
+++ b/ec2-exercises/template.yaml
@@ -9,6 +9,10 @@ Parameters:
       - t3.small
     Description: Type of EC2 Instance to deploy
 
+  EC2InstanceName:
+    Type: String
+    Description: Name to assign to the EC2 Instance
+
 Resources:
   InstanceLaunch:
     Type: AWS::EC2::Instance


### PR DESCRIPTION
## ADD: EC2 Instance Name

### Descripción
Se ha añadido un nuevo parámetro `EC2InstanceName` al template de CloudFormation, que permite asignar un nombre personalizado a la instancia EC2 a través de la propiedad `Tags`. Esto permite identificar fácilmente la instancia dentro de la consola de EC2.

### Cambios
- Parámetro `EC2InstanceName` agregado.
- Etiqueta `Name` aplicada a la instancia EC2.
