### PR TITLE
ADD: new instance name update fixed

### DIFF
--- a/ec2-exercises/template.yaml
+++ b/ec2-exercises/template.yaml
@@ -22,6 +22,9 @@ Resources:
       InstanceType: !Ref EC2InstanceType
       SecurityGroups:
         - !Ref HTTPSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Ref EC2InstanceName
 
   HTTPSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
## ADD: New Instance Name Update Fixed

### Descripción
Se ha corregido la actualización del nombre de la instancia EC2. Ahora, el template permite asignar correctamente un nombre personalizado a la instancia EC2 a través del parámetro `EC2InstanceName`, y este nombre se refleja en la consola de EC2 mediante la etiqueta `Name`.

### Cambios
- Corrección en la referencia al parámetro `EC2InstanceName` para aplicar la etiqueta `Name` a la instancia EC2.
