### PR TITLE
ADD: cognito users group

### DIFF
--- a/cognito-ex/template.yaml
+++ b/cognito-ex/template.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09" 
+Description: Cognito user pool and user group
+
+Parameters:
+  CognitoGroupName:
+    Type: String 
+    Description: Cognito users group name 
+
+Resources:
+  UserPool: 
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: project-05-userpool
+      AutoVerifiedAttributes:
+        - email 
+      Policies: 
+        PasswordPolicy:
+          MinimumLength: 8
+          RequireUppercase: true
+          RequireLowercase: true
+          RequireNumbers: true
+          RequireSymbols: true
+
+  CognitoUserGroup:
+    Type: AWS::Cognito::UserPoolGroup
+    Properties:
+      GroupName: !Ref CognitoGroupName
+      UserPoolId: !Ref UserPool
+      Description: Group for managing user access
+      Precedence: 1


### PR DESCRIPTION
# Template de CloudFormation para AWS Cognito

Este template de AWS CloudFormation crea un **User Pool** y un **grupo de usuarios** en Amazon Cognito. Permite a los usuarios definir el nombre del grupo de usuarios al momento de desplegar el stack.

## Recursos creados

- **Cognito User Pool**: 
  - Nombre: `project-05-userpool`
  - Verificación automática de correos electrónicos.
  - Políticas de contraseña que requieren:
    - Mínimo 8 caracteres.
    - Al menos una letra mayúscula, minúscula, un número y un símbolo.

- **Cognito User Pool Group**:
  - Nombre: Definido por el usuario mediante el parámetro `CognitoGroupName`.
  - Descripción: "Grupo para gestionar el acceso de usuarios".
  - Precedencia: 1 (mayor prioridad).

## Parámetros

- **CognitoGroupName**: Nombre del grupo de usuarios de Cognito.
